### PR TITLE
Create Resistance Zero UI proof of concept

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,624 @@
+const STORAGE_KEY = "rz-state-v1";
+const today = () => new Date().toISOString().slice(0, 10);
+const clone = (value) =>
+  typeof structuredClone === "function"
+    ? structuredClone(value)
+    : JSON.parse(JSON.stringify(value));
+
+const defaultState = {
+  tasks: [],
+  settings: {
+    scanDirection: "forward",
+  },
+  metrics: {
+    totalScans: 0,
+    dottedToday: 0,
+  },
+  daily: {},
+  tipsIndex: 0,
+};
+
+let state = loadState();
+let currentMode = "list";
+let scanSession = null;
+let activeTimer = null;
+
+const guidanceByMode = {
+  list: [
+    "Empty your head. Capture everything without judging it.",
+    "Projects, steps, meta-thoughts—all belong in one flat list.",
+    "Re-entry is a feature: add recurring tasks freely.",
+  ],
+  scan: [
+    "Choose a direction and stick with it. Scanning melts resistance.",
+    "Dot only what feels effortless right now—no forcing.",
+    "Quick passes beat deliberation. Trust the hunches.",
+  ],
+  action: [
+    "Little and often wins. Even two minutes moves the needle.",
+    "After you act, re-enter unfinished work at the end of the list.",
+    "Notice how dotted tasks invite you forward—flow with them.",
+  ],
+  maintain: [
+    "Listen for tasks that now say ‘delete me’.",
+    "Archiving preserves history without cluttering your list.",
+    "Recurring items can be re-entered as soon as they’re needed.",
+  ],
+  reflect: [
+    "Celebrate touch counts: resistance is already lower.",
+    "Look for clumps of similar wins—they reveal momentum.",
+    "Keep reflection light. Notice and move forward.",
+  ],
+};
+
+const coachTips = [
+  "Scanning chips away resistance. Keep passing through!",
+  "If a dotted task resists, split it and keep moving.",
+  "Re-entry isn’t failure—it’s the Resistance Zero rhythm.",
+  "Stay in one mode at a time to feel the guidance working.",
+  "Delete the stale. Make space for the effortless.",
+];
+
+const elements = {
+  guidanceBar: document.getElementById("guidanceBar"),
+  coachTips: document.getElementById("coachTips"),
+  modeButtons: Array.from(document.querySelectorAll(".mode-button")),
+  panels: {
+    list: document.getElementById("listMode"),
+    scan: document.getElementById("scanMode"),
+    action: document.getElementById("actionMode"),
+    maintain: document.getElementById("maintainMode"),
+    reflect: document.getElementById("reflectMode"),
+  },
+  taskForm: document.getElementById("taskForm"),
+  taskText: document.getElementById("taskText"),
+  taskResistance: document.getElementById("taskResistance"),
+  taskLevel: document.getElementById("taskLevel"),
+  taskNotes: document.getElementById("taskNotes"),
+  listPreview: document.getElementById("listPreview"),
+  scanDirectionButtons: Array.from(document.querySelectorAll(".scan-direction")),
+  startScan: document.getElementById("startScan"),
+  scanView: document.getElementById("scanView"),
+  scanStatus: document.getElementById("scanStatus"),
+  actionList: document.getElementById("actionList"),
+  maintenanceList: document.getElementById("maintenanceList"),
+  completedList: document.getElementById("completedList"),
+  archivedList: document.getElementById("archivedList"),
+  metrics: {
+    total: document.getElementById("metricTotalTasks"),
+    dotted: document.getElementById("metricDotted"),
+    active: document.getElementById("metricActive"),
+  },
+  insights: {
+    scans: document.getElementById("insightScans"),
+    dots: document.getElementById("insightDots"),
+    minutes: document.getElementById("insightMinutes"),
+  },
+};
+
+elements.modeButtons.forEach((button) => {
+  button.addEventListener("click", () => setMode(button.dataset.mode));
+});
+
+elements.taskForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const text = elements.taskText.value.trim();
+  if (!text) return;
+  const task = createTask({
+    text,
+    resistance: elements.taskResistance.value ? Number(elements.taskResistance.value) : null,
+    level: elements.taskLevel.value,
+    notes: elements.taskNotes.value.trim(),
+  });
+  state.tasks.push(task);
+  saveState();
+  elements.taskForm.reset();
+  elements.taskText.focus();
+  render();
+});
+
+elements.scanDirectionButtons.forEach((btn) => {
+  btn.addEventListener("click", () => {
+    state.settings.scanDirection = btn.dataset.direction;
+    saveState();
+    highlightScanDirection();
+  });
+});
+
+elements.startScan.addEventListener("click", () => {
+  if (!state.tasks.some((t) => t.status === "active")) {
+    elements.scanStatus.textContent = "Add tasks in List Building mode to start scanning.";
+    return;
+  }
+  beginScan();
+});
+
+function setMode(mode) {
+  currentMode = mode;
+  elements.modeButtons.forEach((button) => {
+    button.classList.toggle("active", button.dataset.mode === mode);
+  });
+  Object.entries(elements.panels).forEach(([key, panel]) => {
+    panel.classList.toggle("hidden", key !== mode);
+  });
+  updateGuidance();
+  render();
+}
+
+function updateGuidance() {
+  const messages = guidanceByMode[currentMode] || [];
+  const message = messages[Math.floor(Math.random() * messages.length)] || "";
+  elements.guidanceBar.textContent = message;
+  const tip = coachTips[state.tipsIndex % coachTips.length];
+  elements.coachTips.textContent = tip;
+  state.tipsIndex = (state.tipsIndex + 1) % coachTips.length;
+}
+
+function highlightScanDirection() {
+  elements.scanDirectionButtons.forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.direction === state.settings.scanDirection);
+  });
+}
+
+function createTask({ text, resistance, level, notes }) {
+  const now = Date.now();
+  return {
+    id: randomId(),
+    text,
+    resistance,
+    level,
+    notes,
+    dotted: false,
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+    touches: 0,
+    scanCount: 0,
+    dottedCount: 0,
+    reentries: 0,
+    completedAt: null,
+    archivedAt: null,
+    timeLogs: [],
+  };
+}
+
+function render() {
+  highlightScanDirection();
+  renderListPreview();
+  renderActionList();
+  renderMaintenanceList();
+  renderReflection();
+  updateMetrics();
+  if (currentMode === "scan") {
+    renderScanView();
+  }
+  saveState();
+}
+
+function renderListPreview() {
+  elements.listPreview.innerHTML = "";
+  state.tasks
+    .filter((task) => task.status === "active")
+    .forEach((task) => {
+      const item = document.createElement("li");
+      item.textContent = `${task.text}${task.dotted ? " • dotted" : ""}`;
+      elements.listPreview.appendChild(item);
+    });
+}
+
+function beginScan() {
+  const tasks = getActiveTasks();
+  const ordered = state.settings.scanDirection === "forward" ? tasks : [...tasks].reverse();
+  scanSession = {
+    order: ordered.map((task) => task.id),
+    index: 0,
+    startedAt: Date.now(),
+  };
+  elements.scanStatus.textContent = "Scanning in progress. Move quickly and trust intuition.";
+  renderScanView();
+}
+
+function renderScanView() {
+  if (!scanSession) {
+    elements.scanView.classList.remove("active");
+    elements.scanView.textContent = "Tap Start Scan to begin a full pass.";
+    return;
+  }
+
+  if (scanSession.index >= scanSession.order.length) {
+    completeScan();
+    return;
+  }
+
+  const taskId = scanSession.order[scanSession.index];
+  const task = state.tasks.find((t) => t.id === taskId);
+  if (!task || task.status !== "active") {
+    scanSession.index += 1;
+    renderScanView();
+    return;
+  }
+
+  elements.scanView.classList.add("active");
+  elements.scanView.innerHTML = "";
+
+  const container = document.createElement("div");
+  container.className = "task-card";
+
+  const header = document.createElement("header");
+  const title = document.createElement("h3");
+  title.textContent = task.text;
+  const badges = document.createElement("div");
+  badges.className = "badges";
+  if (task.level && task.level !== "unspecified") {
+    const badge = document.createElement("span");
+    badge.className = `badge ${task.level}`;
+    badge.textContent = task.level;
+    badges.appendChild(badge);
+  }
+  if (typeof task.resistance === "number") {
+    const badge = document.createElement("span");
+    badge.className = "badge";
+    badge.textContent = `Resistance: ${task.resistance}`;
+    badges.appendChild(badge);
+  }
+  header.appendChild(title);
+  header.appendChild(badges);
+
+  const notes = document.createElement("p");
+  notes.className = "muted";
+  notes.textContent = task.notes || "";
+
+  const footer = document.createElement("footer");
+  const dotButton = document.createElement("button");
+  dotButton.className = "primary";
+  dotButton.textContent = task.dotted ? "Undot" : "Dot (zero resistance)";
+  dotButton.addEventListener("click", () => {
+    toggleDot(task.id);
+  });
+
+  const skipButton = document.createElement("button");
+  skipButton.textContent = "Next";
+  skipButton.addEventListener("click", () => advanceScan());
+
+  footer.appendChild(dotButton);
+  footer.appendChild(skipButton);
+
+  if (task.notes) {
+    container.append(header, notes, footer);
+  } else {
+    container.append(header, footer);
+  }
+
+  elements.scanView.appendChild(container);
+}
+
+function advanceScan() {
+  if (!scanSession) return;
+  const taskId = scanSession.order[scanSession.index];
+  const task = state.tasks.find((t) => t.id === taskId);
+  if (task) {
+    task.touches += 1;
+    task.scanCount += 1;
+    task.updatedAt = Date.now();
+    if (typeof task.resistance === "number" && task.resistance > 0) {
+      task.resistance = Math.max(0, task.resistance - 1);
+    }
+  }
+  scanSession.index += 1;
+  saveState();
+  renderScanView();
+}
+
+function toggleDot(taskId) {
+  const task = state.tasks.find((t) => t.id === taskId);
+  if (!task) return;
+  task.dotted = !task.dotted;
+  task.updatedAt = Date.now();
+  if (task.dotted) {
+    task.dottedCount += 1;
+    bumpDaily(today(), "dots", 1);
+    elements.scanStatus.textContent = "Nice! Dotting marks the effortless tasks.";
+  } else {
+    elements.scanStatus.textContent = "Dot removed. Keep scanning.";
+  }
+  saveState();
+  render();
+}
+
+function completeScan() {
+  elements.scanStatus.textContent = "Scan complete. Move to Action mode when ready.";
+  elements.scanView.classList.remove("active");
+  elements.scanView.textContent = "Scan finished. Great work.";
+  state.metrics.totalScans += 1;
+  bumpDaily(today(), "scans", 1);
+  scanSession = null;
+  saveState();
+  render();
+}
+
+function renderActionList() {
+  if (currentMode !== "action") return;
+  elements.actionList.innerHTML = "";
+  const dottedTasks = state.tasks.filter((task) => task.status === "active" && task.dotted);
+  if (dottedTasks.length === 0) {
+    elements.actionList.textContent = "Dot tasks in Scanning mode to see them here.";
+    return;
+  }
+
+  dottedTasks.forEach((task) => {
+    const card = buildTaskCard(task, {
+      showTimer: true,
+      actions: [
+        {
+          label: task.dotted ? "Clear Dot" : "Dot",
+          onClick: () => toggleDot(task.id),
+        },
+        {
+          label: "Progress Made",
+          onClick: () => progressTask(task.id),
+        },
+        {
+          label: "Complete",
+          onClick: () => completeTask(task.id),
+          className: "primary",
+        },
+      ],
+    });
+    elements.actionList.appendChild(card);
+  });
+}
+
+function renderMaintenanceList() {
+  if (currentMode !== "maintain") return;
+  elements.maintenanceList.innerHTML = "";
+  const activeTasks = state.tasks.filter((task) => task.status === "active");
+  if (activeTasks.length === 0) {
+    elements.maintenanceList.textContent = "Nothing to prune. Add tasks or re-enter recurring work.";
+    return;
+  }
+  activeTasks.forEach((task) => {
+    const card = buildTaskCard(task, {
+      actions: [
+        {
+          label: "Archive",
+          onClick: () => archiveTask(task.id),
+          className: "destructive",
+        },
+      ],
+    });
+    elements.maintenanceList.appendChild(card);
+  });
+}
+
+function renderReflection() {
+  if (currentMode !== "reflect") return;
+  const day = today();
+  const dailyStats = state.daily[day] || { scans: 0, dots: 0, minutes: 0 };
+  elements.insights.scans.textContent = `Scans today: ${dailyStats.scans || 0}`;
+  elements.insights.dots.textContent = `Tasks dotted today: ${dailyStats.dots || 0}`;
+  elements.insights.minutes.textContent = `Minutes logged: ${Math.round(dailyStats.minutes || 0)}`;
+
+  elements.completedList.innerHTML = "";
+  elements.archivedList.innerHTML = "";
+
+  state.tasks
+    .filter((task) => task.status === "completed")
+    .sort((a, b) => (b.completedAt || 0) - (a.completedAt || 0))
+    .forEach((task) => {
+      const item = document.createElement("li");
+      item.className = "reflection-item";
+      item.textContent = `${task.text} • ${(task.timeLogs.reduce((acc, log) => acc + log.minutes, 0) || 0).toFixed(1)} min`;
+      elements.completedList.appendChild(item);
+    });
+
+  state.tasks
+    .filter((task) => task.status === "archived")
+    .sort((a, b) => (b.archivedAt || 0) - (a.archivedAt || 0))
+    .forEach((task) => {
+      const item = document.createElement("li");
+      item.className = "reflection-item";
+      item.textContent = `${task.text} • touched ${task.touches} times`;
+      elements.archivedList.appendChild(item);
+    });
+}
+
+function buildTaskCard(task, options = {}) {
+  const card = document.createElement("article");
+  card.className = "task-card";
+
+  const header = document.createElement("header");
+  const title = document.createElement("h3");
+  title.textContent = task.text;
+  header.appendChild(title);
+
+  const detail = document.createElement("div");
+  detail.className = "muted";
+  const bits = [];
+  if (task.level && task.level !== "unspecified") bits.push(capitalize(task.level));
+  if (typeof task.resistance === "number") bits.push(`Resistance ${task.resistance}`);
+  bits.push(`Touches ${task.touches}`);
+  if (task.reentries) bits.push(`Re-entries ${task.reentries}`);
+  detail.textContent = bits.join(" • ");
+
+  const actions = document.createElement("footer");
+
+  if (options.showTimer) {
+    const timer = document.createElement("div");
+    timer.className = "timer-controls";
+    const status = document.createElement("span");
+    status.textContent = formatTimerStatus(task.id);
+    timer.appendChild(status);
+
+    const toggleTimer = document.createElement("button");
+    toggleTimer.textContent = isTimerRunning(task.id) ? "Stop Timer" : "Start Timer";
+    toggleTimer.addEventListener("click", () => toggleTaskTimer(task.id));
+    timer.appendChild(toggleTimer);
+
+    actions.appendChild(timer);
+  }
+
+  (options.actions || []).forEach((action) => {
+    const btn = document.createElement("button");
+    btn.textContent = action.label;
+    if (action.className) btn.classList.add(action.className);
+    btn.addEventListener("click", action.onClick);
+    actions.appendChild(btn);
+  });
+
+  card.append(header, detail);
+  if (task.notes) {
+    const notes = document.createElement("div");
+    notes.className = "muted";
+    notes.textContent = task.notes;
+    card.appendChild(notes);
+  }
+  card.appendChild(actions);
+  return card;
+}
+
+function formatTimerStatus(taskId) {
+  const task = state.tasks.find((t) => t.id === taskId);
+  if (!task) return "";
+  const totalMinutes = task.timeLogs.reduce((acc, log) => acc + log.minutes, 0);
+  if (isTimerRunning(taskId)) {
+    const now = Date.now();
+    const elapsed = (now - activeTimer.startedAt) / 60000;
+    return `Timing… ${(totalMinutes + elapsed).toFixed(1)} min logged`;
+  }
+  return `${totalMinutes.toFixed(1)} min logged`;
+}
+
+function isTimerRunning(taskId) {
+  return activeTimer && activeTimer.taskId === taskId;
+}
+
+function toggleTaskTimer(taskId) {
+  if (isTimerRunning(taskId)) {
+    stopTimer();
+  } else {
+    startTimer(taskId);
+  }
+  render();
+}
+
+function startTimer(taskId) {
+  stopTimer();
+  activeTimer = {
+    taskId,
+    startedAt: Date.now(),
+  };
+}
+
+function stopTimer() {
+  if (!activeTimer) return;
+  const task = state.tasks.find((t) => t.id === activeTimer.taskId);
+  if (!task) {
+    activeTimer = null;
+    return;
+  }
+  const elapsedMinutes = (Date.now() - activeTimer.startedAt) / 60000;
+  task.timeLogs.push({ minutes: elapsedMinutes, finishedAt: Date.now() });
+  bumpDaily(today(), "minutes", elapsedMinutes);
+  task.updatedAt = Date.now();
+  activeTimer = null;
+  saveState();
+}
+
+function progressTask(taskId) {
+  const index = state.tasks.findIndex((t) => t.id === taskId);
+  if (index === -1) return;
+  if (isTimerRunning(taskId)) stopTimer();
+  const [task] = state.tasks.splice(index, 1);
+  task.reentries += 1;
+  task.updatedAt = Date.now();
+  task.dotted = false;
+  state.tasks.push(task);
+  saveState();
+  render();
+}
+
+function completeTask(taskId) {
+  const task = state.tasks.find((t) => t.id === taskId);
+  if (!task) return;
+  if (isTimerRunning(taskId)) stopTimer();
+  task.status = "completed";
+  task.dotted = false;
+  task.completedAt = Date.now();
+  task.updatedAt = Date.now();
+  saveState();
+  render();
+}
+
+function archiveTask(taskId) {
+  const task = state.tasks.find((t) => t.id === taskId);
+  if (!task) return;
+  if (isTimerRunning(taskId)) stopTimer();
+  task.status = "archived";
+  task.dotted = false;
+  task.archivedAt = Date.now();
+  task.updatedAt = Date.now();
+  saveState();
+  render();
+}
+
+function updateMetrics() {
+  const total = state.tasks.length;
+  const dotted = state.tasks.filter((task) => task.dotted && task.status === "active").length;
+  const active = state.tasks.filter((task) => task.status === "active").length;
+  elements.metrics.total.textContent = `Total Tasks: ${total}`;
+  elements.metrics.dotted.textContent = `Dotted: ${dotted}`;
+  elements.metrics.active.textContent = `Active: ${active}`;
+}
+
+function getActiveTasks() {
+  return state.tasks.filter((task) => task.status === "active");
+}
+
+function bumpDaily(day, key, increment) {
+  if (!state.daily[day]) {
+    state.daily[day] = { scans: 0, dots: 0, minutes: 0 };
+  }
+  state.daily[day][key] += increment;
+  if (key === "dots") {
+    state.metrics.dottedToday += increment;
+  }
+  saveState();
+}
+
+function capitalize(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return clone(defaultState);
+    const parsed = JSON.parse(raw);
+    return { ...clone(defaultState), ...parsed, tasks: parsed.tasks || [], daily: parsed.daily || {} };
+  } catch (error) {
+    console.warn("Unable to load saved data", error);
+    return clone(defaultState);
+  }
+}
+
+function randomId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return "id-" + Math.random().toString(36).slice(2, 10);
+}
+
+function saveState() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    console.warn("Unable to save state", error);
+  }
+}
+
+window.addEventListener("beforeunload", () => {
+  stopTimer();
+  saveState();
+});
+
+setMode("list");

--- a/index.html
+++ b/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Resistance Zero – POC</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Resistance Zero</h1>
+      <div class="guidance" id="guidanceBar">
+        Welcome! Choose a mode to get started.
+      </div>
+    </header>
+
+    <main class="app">
+      <section class="modes">
+        <button class="mode-button" data-mode="list">List Building</button>
+        <button class="mode-button" data-mode="scan">Scanning</button>
+        <button class="mode-button" data-mode="action">Action</button>
+        <button class="mode-button" data-mode="maintain">Maintenance</button>
+        <button class="mode-button" data-mode="reflect">Reflection</button>
+      </section>
+
+      <section class="content">
+        <div id="listMode" class="mode-panel">
+          <h2>Capture tasks with zero friction</h2>
+          <form id="taskForm" class="task-form">
+            <label>
+              Task
+              <input type="text" id="taskText" required placeholder="Write the next thing on your mind" />
+            </label>
+            <label>
+              Resistance (0-10)
+              <input type="number" id="taskResistance" min="0" max="10" />
+            </label>
+            <label>
+              Level
+              <select id="taskLevel">
+                <option value="unspecified">Unspecified</option>
+                <option value="project">Project</option>
+                <option value="step">Step</option>
+                <option value="meta">Meta</option>
+              </select>
+            </label>
+            <label>
+              Notes
+              <textarea id="taskNotes" rows="2" placeholder="Optional context or links"></textarea>
+            </label>
+            <button type="submit">Add Task</button>
+          </form>
+
+          <div class="list-preview">
+            <h3>Current List</h3>
+            <ul id="listPreview"></ul>
+          </div>
+        </div>
+
+        <div id="scanMode" class="mode-panel hidden">
+          <h2>Scan the entire list in one direction</h2>
+          <div class="scan-controls">
+            <div>
+              Scan Direction:
+              <button type="button" data-direction="forward" class="scan-direction">Forward</button>
+              <button type="button" data-direction="backward" class="scan-direction">Backward</button>
+            </div>
+            <button type="button" id="startScan">Start Scan</button>
+            <div id="scanStatus"></div>
+          </div>
+          <div class="scan-view" id="scanView"></div>
+        </div>
+
+        <div id="actionMode" class="mode-panel hidden">
+          <h2>Act on dotted tasks</h2>
+          <p class="mode-tip">Take a small step, log time if useful, then confirm what happened.</p>
+          <div id="actionList" class="task-list"></div>
+        </div>
+
+        <div id="maintainMode" class="mode-panel hidden">
+          <h2>Maintenance</h2>
+          <p class="mode-tip">Delete what no longer belongs. Archived tasks stay visible in Reflection.</p>
+          <div id="maintenanceList" class="task-list"></div>
+        </div>
+
+        <div id="reflectMode" class="mode-panel hidden">
+          <h2>Reflection</h2>
+          <div class="reflection-insights">
+            <div class="insight" id="insightScans">Scans today: 0</div>
+            <div class="insight" id="insightDots">Tasks dotted today: 0</div>
+            <div class="insight" id="insightMinutes">Minutes logged: 0</div>
+          </div>
+          <div class="reflection-lists">
+            <div>
+              <h3>Completed</h3>
+              <ul id="completedList"></ul>
+            </div>
+            <div>
+              <h3>Archived</h3>
+              <ul id="archivedList"></ul>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <div id="metrics">
+        <span id="metricTotalTasks">Total Tasks: 0</span>
+        <span id="metricDotted">Dotted: 0</span>
+        <span id="metricActive">Active: 0</span>
+      </div>
+      <div id="coachTips">Scanning chips away resistance. Keep passing through!</div>
+    </footer>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,326 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f4f6f8;
+  --surface: #ffffffcc;
+  --border: #cdd5df;
+  --primary: #0038ff;
+  --accent: #03a87c;
+  --danger: #e63946;
+  --text: #1c2333;
+  --muted: #5c6b8a;
+  font-family: "Inter", "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(180deg, #fefefe 0%, #eef2f8 100%);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  padding: 1.5rem;
+  background: var(--surface);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.guidance {
+  margin-top: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.app {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  flex: 1 1 auto;
+}
+
+.modes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mode-button {
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.mode-button.active {
+  border-color: var(--primary);
+  box-shadow: 0 12px 24px -18px var(--primary);
+  color: var(--primary);
+}
+
+.mode-button:hover {
+  transform: translateY(-1px);
+}
+
+.content {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.5rem;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.mode-panel h2 {
+  margin-top: 0;
+  font-size: 1.3rem;
+}
+
+.mode-panel.hidden {
+  display: none;
+}
+
+.task-form {
+  display: grid;
+  gap: 1rem;
+  max-width: 500px;
+}
+
+.task-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.task-form input,
+.task-form textarea,
+.task-form select {
+  padding: 0.75rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  font-size: 1rem;
+  font-family: inherit;
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.task-form button {
+  padding: 0.9rem 1.2rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--primary);
+  color: white;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.list-preview ul,
+.task-list ul,
+.reflection-lists ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.list-preview li,
+.task-card,
+.reflection-item {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.task-card {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.task-card header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.task-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: rgba(0, 56, 255, 0.08);
+  color: var(--primary);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badge.meta { background: rgba(154, 99, 255, 0.1); color: #6236ff; }
+.badge.project { background: rgba(255, 179, 0, 0.15); color: #a96800; }
+.badge.step { background: rgba(0, 168, 124, 0.15); color: #008c6a; }
+
+.task-card footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.task-card button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+
+.task-card button.primary {
+  background: var(--accent);
+  border-color: transparent;
+  color: #fff;
+}
+
+.task-card button.destructive {
+  background: rgba(230, 57, 70, 0.1);
+  color: var(--danger);
+  border-color: rgba(230, 57, 70, 0.2);
+}
+
+.task-card .timer-controls {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.scan-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.scan-direction.active {
+  background: rgba(0, 56, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  border: 1px solid var(--primary);
+}
+
+.scan-view {
+  min-height: 180px;
+  border: 2px dashed var(--border);
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.scan-view.active {
+  border-color: var(--primary);
+  color: var(--text);
+}
+
+.mode-tip {
+  color: var(--muted);
+  margin-top: -0.5rem;
+}
+
+.reflection-insights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.insight {
+  background: rgba(0, 56, 255, 0.08);
+  border-radius: 14px;
+  padding: 1rem;
+  font-weight: 600;
+}
+
+.reflection-lists {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.app-footer {
+  padding: 1rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+}
+
+#metrics {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-weight: 600;
+}
+
+#coachTips {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 900px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .modes {
+    flex-direction: row;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+  }
+
+  .mode-button {
+    flex: 1 0 150px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static single-page Resistance Zero UI scaffold with mode switcher and guidance
- implement task management logic with localStorage persistence, scanning workflow, and action/maintenance/reflection behaviors
- style the interface for mobile-friendly GitHub Pages deployment and include contextual coaching prompts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d950d0a8208324a527fc4c2db93567