### PR TITLE
Add settings mode and swipe-to-delete for list building

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
         <button class="mode-button" data-mode="action">Action</button>
         <button class="mode-button" data-mode="maintain">Maintenance</button>
         <button class="mode-button" data-mode="reflect">Reflection</button>
+        <button class="mode-button" data-mode="settings">Settings</button>
       </section>
 
       <section class="content">
@@ -32,16 +33,6 @@
 
           <div class="task-list-view">
             <ul id="listPreview" class="task-list-items"></ul>
-          </div>
-
-          <div class="scan-direction-setting">
-            <label>
-              Scan Direction
-              <select id="scanDirectionSelect">
-                <option value="forward">Forward (first to last)</option>
-                <option value="backward">Backward (last to first)</option>
-              </select>
-            </label>
           </div>
 
           <div id="expandedForm" class="expanded-form hidden">
@@ -130,6 +121,25 @@
               <ul id="archivedList"></ul>
             </div>
           </div>
+        </div>
+
+        <div id="settingsMode" class="mode-panel hidden">
+          <h2>Settings</h2>
+          <p class="mode-tip">Adjust how Resistance Zero behaves to match your flow.</p>
+
+          <section class="settings-section">
+            <h3>Scanning</h3>
+            <div class="setting-option">
+              <div>
+                <div class="setting-label">Scan Direction</div>
+                <div class="setting-description">Choose the order tasks appear when scanning.</div>
+              </div>
+              <select id="settingsScanDirection">
+                <option value="forward">Forward (first to last)</option>
+                <option value="backward">Backward (last to first)</option>
+              </select>
+            </div>
+          </section>
         </div>
       </section>
     </main>

--- a/styles.css
+++ b/styles.css
@@ -283,6 +283,58 @@ body {
   gap: 1.5rem;
 }
 
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  background: rgba(0, 56, 255, 0.06);
+  border-radius: 16px;
+  padding: 1.25rem;
+}
+
+.setting-option {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.setting-label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.setting-description {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.setting-option select {
+  border-radius: 12px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+  font-size: 0.95rem;
+  min-width: 220px;
+}
+
+.task-list-items li.swipeable {
+  position: relative;
+  touch-action: pan-y;
+  will-change: transform;
+  transition: transform 0.18s ease, opacity 0.18s ease;
+}
+
+.task-list-items li.dragging {
+  transition: none;
+}
+
+.task-list-items li.deleting {
+  opacity: 0;
+  transform: translateX(-100%);
+}
+
 .app-footer {
   padding: 1rem 1.5rem 1.5rem;
   display: flex;
@@ -655,28 +707,6 @@ body {
   .big-scan-button:hover {
     transform: translateY(-2px);
     box-shadow: 0 6px 20px rgba(0, 56, 255, 0.4);
-  }
-
-  .scan-direction-setting {
-    margin-top: 1rem;
-    padding: 0.75rem;
-    background: rgba(0, 0, 0, 0.02);
-    border-radius: 8px;
-  }
-
-  .scan-direction-setting label {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    font-size: 0.9rem;
-    font-weight: 600;
-  }
-
-  .scan-direction-setting select {
-    padding: 0.5rem;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    font-size: 0.9rem;
   }
 
   .scan-progress {


### PR DESCRIPTION
## Summary
- add a dedicated Settings mode that hosts the scan direction preference
- enable swipe-to-delete gestures for tasks in the List Building view
- update styling to support the new settings layout and swipe affordances

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d97e52cb148324b4c0b6d2b91b69b8