### PR TITLE
Add manual testing guide for PWA shell

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,32 @@
+# Testing Resistance Zero PWA
+
+These steps verify that the install prompt, manifest, and service worker are correctly wired up for the Resistance Zero PWA shell.
+
+## 1. Start a local web server
+
+```bash
+python -m http.server 4173
+```
+
+Serving over `http://127.0.0.1` (or `localhost`) is required so modern browsers will allow service worker registration.
+
+## 2. Check manifest and service worker endpoints
+
+In a second terminal, confirm the manifest and service worker files are reachable:
+
+```bash
+curl -I http://127.0.0.1:4173/manifest.json
+curl -I http://127.0.0.1:4173/service-worker.js
+```
+
+Each request should return a `200 OK` response.
+
+## 3. Verify install UI and service worker in the browser
+
+1. Visit `http://127.0.0.1:4173/` in Chromium or another modern browser.
+2. Open DevTools → Application → Manifest to verify the app metadata and icon load without errors.
+3. In the Application → Service Workers panel, confirm that `service-worker.js` is installed and activated.
+4. Trigger the `beforeinstallprompt` event (e.g. via DevTools) to surface the **Install App** button and confirm the prompt can be accepted or dismissed.
+5. Modify `service-worker.js` (or bump `CACHE_VERSION`) and reload the page to see the update toast asking the user to refresh.
+
+These manual checks ensure the install button, manifest linkage, service worker caching, and update notifications all function as intended.

--- a/icons/icon.svg
+++ b/icons/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="72" fill="url(#bg)" />
+  <g fill="none" stroke="#f8fafc" stroke-width="32" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M128 192h144c32 0 56 24 56 56s-24 56-56 56h-80" />
+    <path d="M272 192 176 320" />
+    <circle cx="344" cy="248" r="56" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#2563eb" />
+    <link rel="manifest" href="manifest.json" />
+    <link rel="icon" href="icons/icon.svg" type="image/svg+xml" />
     <title>Resistance Zero – POC</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
@@ -12,6 +15,9 @@
       <div class="guidance" id="guidanceBar">
         Welcome! Choose a mode to get started.
       </div>
+      <button id="installButton" class="install-btn hidden" type="button" aria-hidden="true">
+        Install App
+      </button>
     </header>
 
     <main class="app">
@@ -256,6 +262,20 @@
 
       </section>
     </main>
+
+    <div
+      id="updateToast"
+      class="update-toast hidden"
+      role="status"
+      aria-live="polite"
+      aria-hidden="true"
+    >
+      <span class="update-message">A new version of Resistance Zero is available.</span>
+      <div class="update-actions">
+        <button id="refreshApp" type="button" class="update-btn primary">Refresh now</button>
+        <button id="dismissUpdate" type="button" class="update-btn">Later</button>
+      </div>
+    </div>
 
     <footer class="app-footer">
       <div id="metrics">

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "Resistance Zero",
+  "short_name": "ResZero",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#2563eb",
+  "description": "Guided workflow for navigating resistance and taking action.",
+  "icons": [
+    {
+      "src": "icons/icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,72 @@
+const CACHE_VERSION = "v2";
+const CACHE_NAME = `rz-cache-${CACHE_VERSION}`;
+const OFFLINE_ASSETS = [
+  "./",
+  "./index.html",
+  "./styles.css",
+  "./app.js",
+  "./manifest.json",
+  "./icons/icon.svg"
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(OFFLINE_ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data?.type === "sw.skipWaiting") {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const cacheKeys = await caches.keys();
+      const keysToDelete = cacheKeys.filter((key) => key !== CACHE_NAME);
+
+      await Promise.all(keysToDelete.map((key) => caches.delete(key)));
+      await self.clients.claim();
+
+      if (keysToDelete.length > 0) {
+        const clients = await self.clients.matchAll({
+          type: "window",
+          includeUncontrolled: true,
+        });
+
+        clients.forEach((client) =>
+          client.postMessage({ type: "sw.updated", version: CACHE_VERSION })
+        );
+      }
+    })()
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => {
+            cache.put(event.request, clone);
+          });
+          return response;
+        })
+        .catch(() => caches.match("./index.html"));
+    })
+  );
+});

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,10 @@ body {
   position: sticky;
   top: 0;
   z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
 }
 
 .app-header h1 {
@@ -38,9 +42,30 @@ body {
 }
 
 .guidance {
-  margin-top: 0.5rem;
   font-size: 0.95rem;
   color: var(--muted);
+}
+
+.install-btn {
+  margin-left: auto;
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 1.1rem;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.install-btn.hidden {
+  display: none !important;
+}
+
+.install-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 28px -18px var(--primary);
 }
 
 .app {
@@ -577,6 +602,53 @@ body {
   border-top: 1px solid var(--border);
 }
 
+.update-toast {
+  position: fixed;
+  inset: auto 1rem 1rem 1rem;
+  background: #0f172a;
+  color: #f8fafc;
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 18px 40px -24px rgba(15, 23, 42, 0.85);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 5;
+}
+
+.update-toast.hidden {
+  display: none !important;
+}
+
+.update-message {
+  font-weight: 600;
+}
+
+.update-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.update-btn {
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+}
+
+.update-btn.primary {
+  background: #38bdf8;
+  color: #0f172a;
+}
+
+.update-btn:hover {
+  filter: brightness(1.05);
+}
+
 #metrics {
   display: flex;
   gap: 1.5rem;
@@ -966,6 +1038,12 @@ body {
     background: var(--primary);
     color: white;
     border-color: var(--primary);
+  }
+}
+
+@media (max-width: 600px) {
+  .update-toast {
+    inset: auto 0.75rem 0.75rem 0.75rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a TESTING.md guide that walks through verifying the PWA install prompt, manifest, and service worker update flow

## Testing
- python -m http.server 4173
- curl -I http://127.0.0.1:4173/manifest.json
- curl -I http://127.0.0.1:4173/service-worker.js


------
https://chatgpt.com/codex/tasks/task_e_68db0704bf148324a3d46b68fde1d9e0