### PR TITLE
Hide header outside of intro view

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,10 @@ body {
   align-items: flex-start;
 }
 
+body:not(:has(#introPage:not(.hidden))) .app-header {
+  display: none;
+}
+
 .app-header h1 {
   margin: 0;
   font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- hide the main app header whenever the intro page is not visible so it only appears on the introduction screen

## Testing
- Manual validation

------
https://chatgpt.com/codex/tasks/task_e_68dc289069508324a1eaf012805a10c8